### PR TITLE
fix: do major, minor Chickensoft updates together

### DIFF
--- a/godot.json
+++ b/godot.json
@@ -25,6 +25,9 @@
       "matchPackageNames": ["GodotSharp{/,}**", "Godot.NET.Sdk{/,}**"]
     },
     {
+      "groupName": "Chickensoft",
+      "groupSlug": "chickensoft",
+      "separateMajorMinor": false,
       "matchPackageNames": ["Chickensoft{/,}**"],
       "allowedVersions": "/^(\\d+\\.\\d+\\.\\d+)(-godot(\\d+\\.)+\\d+(-.*)?)?$/"
     }


### PR DESCRIPTION
When Chickensoft package A depends on Chickensoft packages B and C, and B depends on C, conflicts in renovate PRs can arise if C receives a major version update. If B is auto-updated to reflect the new version of C, it may receive a minor or patch bump. Renovate will then open separate, but individually incomplete and failing, PRs in A for the minor version bump in B and the major version bump in C.

This change should fix the issue by changing the package rules for Chickensoft packages to stop separating major and minor version changes. (See [the renovate docs](https://docs.renovatebot.com/configuration-options/#separatemajorminor) for the configuration option.)