### PR TITLE
feat: limit `CliFx` to <3.0.0 for compiler compat

### DIFF
--- a/godot.json
+++ b/godot.json
@@ -22,6 +22,10 @@
       "enabled": false
     },
     {
+      "matchPackageNames": ["CliFx"],
+      "allowedVersions": "<3.0.0"
+    },
+    {
       "matchPackageNames": ["GodotSharp{/,}**", "Godot.NET.Sdk{/,}**"]
     },
     {


### PR DESCRIPTION
CliFx v3 includes new source generation abilities that require compiler version 5.0. However, since we're currently supporting .NET 8, we're limited to support for compiler v4.11.0. See [my comment on GodotEnv #235](https://github.com/chickensoft-games/GodotEnv/pull/235#issuecomment-4338371909), when renovate attempted to update CliFx.

This change limits all Chickensoft packages to CliFx <3.0 as long as we are on .NET 8 (although I believe this only impacts GodotEnv). This limitation can be removed when we bump to .NET 10.