### PR TITLE
fix: limit more `CodeAnalysis` packages

### DIFF
--- a/godot.json
+++ b/godot.json
@@ -22,6 +22,14 @@
       "enabled": false
     },
     {
+      "matchPackageNames": ["Microsoft.CodeAnalysis.Analyzers"],
+      "allowedVersions": "<4.15.0"
+    },
+    {
+      "matchPackageNames": ["Microsoft.CodeAnalysis.Common"],
+      "allowedVersions": "<4.12.0"
+    },
+    {
       "matchPackageNames": ["CliFx"],
       "allowedVersions": "<3.0.0"
     },


### PR DESCRIPTION
Added new package rules to prevent renovate from updating `CodeAnalysis.Analyzers` and `CodeAnalysis.Common` to incompatible newer versions.

(chickensoft-games/LogicBlocks#247 was hung up trying to update these packages and encountering runtime errors with the diagram generator as a result.)